### PR TITLE
Standardize some formatting

### DIFF
--- a/tests/reading-systems/00_Unclassified/find-the-package-001/FOO/BAR/package.opf
+++ b/tests/reading-systems/00_Unclassified/find-the-package-001/FOO/BAR/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/00_Unclassified/find-the-package-001/META-INF/container.xml
+++ b/tests/reading-systems/00_Unclassified/find-the-package-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="FOO/BAR/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="FOO/BAR/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/00_Unclassified/find-the-package-001/OEBPS/package.opf
+++ b/tests/reading-systems/00_Unclassified/find-the-package-001/OEBPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/00_Unclassified/find-the-package-001/OPS/package.opf
+++ b/tests/reading-systems/00_Unclassified/find-the-package-001/OPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/00_Unclassified/find-the-package-002/FOO/BAR/package.opf
+++ b/tests/reading-systems/00_Unclassified/find-the-package-002/FOO/BAR/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/00_Unclassified/find-the-package-002/META-INF/container.xml
+++ b/tests/reading-systems/00_Unclassified/find-the-package-002/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="FOO/BAR/package.opf" media-type="application/oebps-package+xml"/><rootfile full-path="OEBPS/package.opf" media-type="application/oebps-package+xml"/><rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="FOO/BAR/package.opf" media-type="application/oebps-package+xml" /><rootfile full-path="OEBPS/package.opf" media-type="application/oebps-package+xml" /><rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/00_Unclassified/find-the-package-002/OEBPS/package.opf
+++ b/tests/reading-systems/00_Unclassified/find-the-package-002/OEBPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/00_Unclassified/find-the-package-002/OPS/package.opf
+++ b/tests/reading-systems/00_Unclassified/find-the-package-002/OPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-001/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-001/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-001/OPS/package.opf
@@ -9,12 +9,12 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_primary" fallback="content_fallback" href="moby.json" media-type="application/json"/>
+  <item id="content_primary" fallback="content_fallback" href="moby.json" media-type="application/json" />
 
-  <item id="content_fallback" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_fallback" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_primary"/>
+  <itemref idref="content_primary" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-002/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-002/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-002/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-002/OPS/package.opf
@@ -9,12 +9,12 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_primary" fallback="content_fallback" href="moby.xml" media-type="application/dtc+xml"/>
+  <item id="content_primary" fallback="content_fallback" href="moby.xml" media-type="application/dtc+xml" />
 
-  <item id="content_fallback" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_fallback" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_primary"/>
+  <itemref idref="content_primary" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-003/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-003/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-003/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-003/OPS/package.opf
@@ -9,12 +9,12 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_primary" fallback="content_fallback" href="moby.xml" media-type="application/xml"/>
+  <item id="content_primary" fallback="content_fallback" href="moby.xml" media-type="application/xml" />
 
-  <item id="content_fallback" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_fallback" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_primary"/>
+  <itemref idref="content_primary" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-004/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-004/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-004/OPS/content_001.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-004/OPS/content_001.xhtml
@@ -7,7 +7,7 @@
 
 <p>Test passes if you see a snowflake image below.</p>
 
-<img src="p009-star.psd" alt="test fails"/>
+<img src="p009-star.psd" alt="test fails" />
 
 
 

--- a/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-004/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/manifest-fallback-004/OPS/package.opf
@@ -10,13 +10,13 @@
 </metadata>
 <manifest>
 
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-    <item id="image-tiff" href="p009-star.psd" media-type="image/psd" fallback="image-png"/>
-      <item id="image-png" href="Snowflake.png" media-type="image/png"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+    <item id="image-tiff" href="p009-star.psd" media-type="image/psd" fallback="image-png" />
+      <item id="image-png" href="Snowflake.png" media-type="image/png" />
 
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/viewport-css-001/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/viewport-css-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/viewport-css-001/OPS/content_001.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/viewport-css-001/OPS/content_001.xhtml
@@ -454,7 +454,7 @@ td {
     padding: 0;
 }
 </style>
-    <link rel="appendix stylesheet" href="data:text/css,.picture%20%7B%20background%3A%20none%3B%20%7D"/>
+    <link rel="appendix stylesheet" href="data:text/css,.picture%20%7B%20background%3A%20none%3B%20%7D" />
     <!-- this stylesheet should be applied by default -->
 </head>
 <body>
@@ -532,7 +532,7 @@ td {
             <table>
                 <tr>
                     <td>
-                        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAFSDNYfAAAAaklEQVR42u3XQQrAIAwAQeP%2F%2F6wf8CJBJTK9lnQ7FpHGaOurt1I34nfH9pMMZAZ8BwMGEvvh%2BBsJCAgICLwIOA8EBAQEBAQEBAQEBK79H5RfIQAAAAAAAAAAAAAAAAAAAAAAAAAAAID%2FABMSqAfj%2FsLmvAAAAABJRU5ErkJggg%3D%3D" alt=""/>
+                        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAFSDNYfAAAAaklEQVR42u3XQQrAIAwAQeP%2F%2F6wf8CJBJTK9lnQ7FpHGaOurt1I34nfH9pMMZAZ8BwMGEvvh%2BBsJCAgICLwIOA8EBAQEBAQEBAQEBK79H5RfIQAAAAAAAAAAAAAAAAAAAAAAAAAAAID%2FABMSqAfj%2FsLmvAAAAABJRU5ErkJggg%3D%3D" alt="" />
                     </td>
                 </tr>
             </table>
@@ -540,7 +540,7 @@ td {
     </div>
     
     
-    <img src="reference.png" id="reference" alt=""/>
+    <img src="reference.png" id="reference" alt="" />
 </body>
 </html>
 

--- a/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/viewport-css-001/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/EPUB-3-Processing/viewport-css-001/OPS/package.opf
@@ -9,9 +9,9 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
-    <item id="reference" href="reference.png" media-type="image/png"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
+    <item id="reference" href="reference.png" media-type="image/png" />
 
 </manifest>
 <spine>
@@ -21,8 +21,8 @@
 				    
   
 
-<itemref idref="content_001"/>
+<itemref idref="content_001" />
 
-  --><itemref idref="content_001"/>
+  --><itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-base-001/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-base-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-base-001/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-base-001/OPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="base/content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="base/content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-external-entities-001/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-external-entities-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-external-entities-001/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-external-entities-001/OPS/package.opf
@@ -9,12 +9,12 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
-  <item id="foo" href="foo.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
+  <item id="foo" href="foo.xhtml" media-type="application/xhtml+xml" />
 
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-names-001/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-names-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-names-001/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-names-001/OPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-non-validating-parser-001/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-non-validating-parser-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-non-validating-parser-001/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-non-validating-parser-001/OPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-non-validating-parser-002/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-non-validating-parser-002/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-non-validating-parser-002/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/XML-Processing/xml-non-validating-parser-002/OPS/package.opf
@@ -9,8 +9,8 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
 
@@ -19,8 +19,8 @@
 				    
   
 
-<itemref idref="content_001"/>
+<itemref idref="content_001" />
 
-  --><itemref idref="content_001"/>
+  --><itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/backward-compatibility/package-version-000/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/backward-compatibility/package-version-000/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/backward-compatibility/package-version-000/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/backward-compatibility/package-version-000/OPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mp4/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mp4/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mp4/OPS/content_001.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mp4/OPS/content_001.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mp4/OPS/nav.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mp4/OPS/nav.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 <nav epub:type="toc">

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mp4/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mp4/OPS/package.opf
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0" xml:lang="en" unique-identifier="pub-id">
 <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <dc:title>Title TK</dc:title>
-  <dc:date>2021-03-29</dc:date>
-  <dc:creator>Creator TK</dc:creator>
+  <dc:title>Title</dc:title>
+  <dc:date>2021-01-01</dc:date>
+  <dc:creator>Creator</dc:creator>
   <dc:identifier id="pub-id">NOID</dc:identifier>
-  <meta property="dcterms:modified">2021-03-29T00:00:00Z</meta>
+  <meta property="dcterms:modified">2021-01-01T00:00:00Z</meta>
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
   <item id="001.m4a" href="aud/001.m4a" media-type="audio/mp4" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mpeg/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mpeg/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mpeg/OPS/content_001.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mpeg/OPS/content_001.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mpeg/OPS/nav.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mpeg/OPS/nav.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 <nav epub:type="toc">

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mpeg/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-mpeg/OPS/package.opf
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0" xml:lang="en" unique-identifier="pub-id">
 <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <dc:title>Title TK</dc:title>
-  <dc:date>2021-03-29</dc:date>
-  <dc:creator>Creator TK</dc:creator>
+  <dc:title>Title</dc:title>
+  <dc:date>2021-01-01</dc:date>
+  <dc:creator>Creator</dc:creator>
   <dc:identifier id="pub-id">NOID</dc:identifier>
-  <meta property="dcterms:modified">2021-03-29T00:00:00Z</meta>
+  <meta property="dcterms:modified">2021-01-01T00:00:00Z</meta>
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
   <item id="001.mp3" href="aud/001.mp3" media-type="audio/mpeg" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-opus/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-opus/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-opus/OPS/content_001.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-opus/OPS/content_001.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-opus/OPS/nav.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-opus/OPS/nav.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 <nav epub:type="toc">

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-opus/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/audio-opus/OPS/package.opf
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0" xml:lang="en" unique-identifier="pub-id">
 <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <dc:title>Title TK</dc:title>
-  <dc:date>2021-03-29</dc:date>
-  <dc:creator>Creator TK</dc:creator>
+  <dc:title>Title</dc:title>
+  <dc:date>2021-01-01</dc:date>
+  <dc:creator>Creator</dc:creator>
   <dc:identifier id="pub-id">NOID</dc:identifier>
-  <meta property="dcterms:modified">2021-03-29T00:00:00Z</meta>
+  <meta property="dcterms:modified">2021-01-01T00:00:00Z</meta>
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
   <item id="001.opus" href="aud/001.opus" media-type="audio/opus" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-gif/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-gif/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-gif/OPS/content_001.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-gif/OPS/content_001.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-gif/OPS/nav.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-gif/OPS/nav.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 <nav epub:type="toc">

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-gif/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-gif/OPS/package.opf
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0" xml:lang="en" unique-identifier="pub-id">
 <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <dc:title>Title TK</dc:title>
-  <dc:date>2021-03-29</dc:date>
-  <dc:creator>Creator TK</dc:creator>
+  <dc:title>Title</dc:title>
+  <dc:date>2021-01-01</dc:date>
+  <dc:creator>Creator</dc:creator>
   <dc:identifier id="pub-id">NOID</dc:identifier>
-  <meta property="dcterms:modified">2021-03-29T00:00:00Z</meta>
+  <meta property="dcterms:modified">2021-01-01T00:00:00Z</meta>
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
   <item id="001.gif" href="img/001.gif" media-type="image/gif" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-jpeg/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-jpeg/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-jpeg/OPS/content_001.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-jpeg/OPS/content_001.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-jpeg/OPS/nav.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-jpeg/OPS/nav.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 <nav epub:type="toc">

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-jpeg/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-jpeg/OPS/package.opf
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0" xml:lang="en" unique-identifier="pub-id">
 <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <dc:title>Title TK</dc:title>
-  <dc:date>2021-03-29</dc:date>
-  <dc:creator>Creator TK</dc:creator>
+  <dc:title>Title</dc:title>
+  <dc:date>2021-01-01</dc:date>
+  <dc:creator>Creator</dc:creator>
   <dc:identifier id="pub-id">NOID</dc:identifier>
-  <meta property="dcterms:modified">2021-03-29T00:00:00Z</meta>
+  <meta property="dcterms:modified">2021-01-01T00:00:00Z</meta>
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
   <item id="001.jpg" href="img/001.jpg" media-type="image/jpeg" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-png/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-png/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-png/OPS/content_001.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-png/OPS/content_001.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-png/OPS/nav.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-png/OPS/nav.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 <nav epub:type="toc">

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-png/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-png/OPS/package.opf
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0" xml:lang="en" unique-identifier="pub-id">
 <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <dc:title>Title TK</dc:title>
-  <dc:date>2021-03-29</dc:date>
-  <dc:creator>Creator TK</dc:creator>
+  <dc:title>Title</dc:title>
+  <dc:date>2021-01-01</dc:date>
+  <dc:creator>Creator</dc:creator>
   <dc:identifier id="pub-id">NOID</dc:identifier>
-  <meta property="dcterms:modified">2021-03-29T00:00:00Z</meta>
+  <meta property="dcterms:modified">2021-01-01T00:00:00Z</meta>
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
   <item id="001.png" href="img/001.png" media-type="image/png" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-svg/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-svg/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-svg/OPS/content_001.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-svg/OPS/content_001.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-svg/OPS/nav.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-svg/OPS/nav.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 <nav epub:type="toc">

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-svg/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-svg/OPS/package.opf
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0" xml:lang="en" unique-identifier="pub-id">
 <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <dc:title>Title TK</dc:title>
-  <dc:date>2021-03-29</dc:date>
-  <dc:creator>Creator TK</dc:creator>
+  <dc:title>Title</dc:title>
+  <dc:date>2021-01-01</dc:date>
+  <dc:creator>Creator</dc:creator>
   <dc:identifier id="pub-id">NOID</dc:identifier>
-  <meta property="dcterms:modified">2021-03-29T00:00:00Z</meta>
+  <meta property="dcterms:modified">2021-01-01T00:00:00Z</meta>
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
   <item id="001.svg" href="img/001.svg" media-type="image/svg+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-webp/META-INF/container.xml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-webp/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-webp/OPS/content_001.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-webp/OPS/content_001.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-webp/OPS/nav.xhtml
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-webp/OPS/nav.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
-<title>Title TK</title>
+<title>Title</title>
 </head>
 <body>
 <nav epub:type="toc">

--- a/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-webp/OPS/package.opf
+++ b/tests/reading-systems/02_EPUB-Publications/supported-media-types/image-webp/OPS/package.opf
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0" xml:lang="en" unique-identifier="pub-id">
 <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <dc:title>Title TK</dc:title>
-  <dc:date>2021-03-29</dc:date>
-  <dc:creator>Creator TK</dc:creator>
+  <dc:title>Title</dc:title>
+  <dc:date>2021-01-01</dc:date>
+  <dc:creator>Creator</dc:creator>
   <dc:identifier id="pub-id">NOID</dc:identifier>
-  <meta property="dcterms:modified">2021-03-29T00:00:00Z</meta>
+  <meta property="dcterms:modified">2021-01-01T00:00:00Z</meta>
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
   <item id="001.webp" href="img/001.webp" media-type="image/webp" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_1_Package-Document-Conformance/package-unlisted-resources-001/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_1_Package-Document-Conformance/package-unlisted-resources-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_1_Package-Document-Conformance/package-unlisted-resources-001/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_1_Package-Document-Conformance/package-unlisted-resources-001/OPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-creator-dir-rtl-001/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-creator-dir-rtl-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-creator-dir-rtl-001/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-creator-dir-rtl-001/OPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-creator-order-001/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-creator-order-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-creator-order-001/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-creator-order-001/OPS/package.opf
@@ -10,10 +10,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-ignore-unknown-meta-001/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-ignore-unknown-meta-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-ignore-unknown-meta-001/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-ignore-unknown-meta-001/OPS/package.opf
@@ -10,10 +10,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-title-dir-rtl-001/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-title-dir-rtl-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-title-dir-rtl-001/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-title-dir-rtl-001/OPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-title-display-001/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-title-display-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-title-display-001/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-title-display-001/OPS/package.opf
@@ -10,10 +10,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-whitespace-001/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-whitespace-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-whitespace-001/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_2_1_Metadata/package-whitespace-001/OPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_2_Manifest/item-iri-001/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_2_Manifest/item-iri-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_2_Manifest/item-iri-001/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_2_Manifest/item-iri-001/OPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="foo/content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="foo/content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_2_Manifest/unknown-properties-001/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_2_Manifest/unknown-properties-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_2_Manifest/unknown-properties-001/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_2_Manifest/unknown-properties-001/OPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" properties="incandescent" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" properties="incandescent" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/linear-reachable-001/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/linear-reachable-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/linear-reachable-001/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/linear-reachable-001/OPS/package.opf
@@ -9,12 +9,12 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
-  <itemref idref="content_002" linear="no"/>
+  <itemref idref="content_001" />
+  <itemref idref="content_002" linear="no" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/manifest-fallback-005/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/manifest-fallback-005/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/manifest-fallback-005/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/manifest-fallback-005/OPS/package.opf
@@ -10,13 +10,13 @@
 </metadata>
 <manifest>
 
-  <item id="content_001" href="foo.dmg" media-type="application/octet-stream" fallback="bar"/>
-<item id="bar" href="bar.psd" media-type="image/psd"/>
+  <item id="content_001" href="foo.dmg" media-type="application/octet-stream" fallback="bar" />
+<item id="bar" href="bar.psd" media-type="image/psd" />
 
 
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-001/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-001/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-001/OPS/package.opf
@@ -9,18 +9,18 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_003" href="content_003.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_004" href="content_004.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_003" href="content_003.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_004" href="content_004.xhtml" media-type="application/xhtml+xml" />
 
 
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine page-progression-direction="ltr">
-  <itemref idref="content_001"/>
-  <itemref idref="content_002"/>
-  <itemref idref="content_003"/>
-  <itemref idref="content_004"/>
+  <itemref idref="content_001" />
+  <itemref idref="content_002" />
+  <itemref idref="content_003" />
+  <itemref idref="content_004" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-002/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-002/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-002/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-002/OPS/package.opf
@@ -9,18 +9,18 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_003" href="content_003.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_004" href="content_004.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_003" href="content_003.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_004" href="content_004.xhtml" media-type="application/xhtml+xml" />
 
 
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine page-progression-direction="rtl">
-  <itemref idref="content_001"/>
-  <itemref idref="content_002"/>
-  <itemref idref="content_003"/>
-  <itemref idref="content_004"/>
+  <itemref idref="content_001" />
+  <itemref idref="content_002" />
+  <itemref idref="content_003" />
+  <itemref idref="content_004" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-003/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-003/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-003/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-003/OPS/package.opf
@@ -9,18 +9,18 @@
   <dc:language>ar</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_003" href="content_003.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_004" href="content_004.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_003" href="content_003.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_004" href="content_004.xhtml" media-type="application/xhtml+xml" />
 
 
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
-  <itemref idref="content_002"/>
-  <itemref idref="content_003"/>
-  <itemref idref="content_004"/>
+  <itemref idref="content_001" />
+  <itemref idref="content_002" />
+  <itemref idref="content_003" />
+  <itemref idref="content_004" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-004/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-004/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-004/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-004/OPS/package.opf
@@ -10,22 +10,22 @@
   <meta property="rendition:layout">pre-paginated</meta>
 </metadata>
 <manifest>
-  <item id="page_001" href="page_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="page_002" href="page_002.xhtml" media-type="application/xhtml+xml"/>
-  <item id="page_003" href="page_003.xhtml" media-type="application/xhtml+xml"/>
-  <item id="page_004" href="page_004.xhtml" media-type="application/xhtml+xml"/>
-  <item id="style"    href="fixed.css" media-type="text/css"/>
-  <item id="stix-font" href="fonts/STIXTwoText-Regular.otf" media-type="font/otf"/>
-  <item id="murmure-font" href="fonts/le-murmure.otf" media-type="font/otf"/>
+  <item id="page_001" href="page_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="page_002" href="page_002.xhtml" media-type="application/xhtml+xml" />
+  <item id="page_003" href="page_003.xhtml" media-type="application/xhtml+xml" />
+  <item id="page_004" href="page_004.xhtml" media-type="application/xhtml+xml" />
+  <item id="style"    href="fixed.css" media-type="text/css" />
+  <item id="stix-font" href="fonts/STIXTwoText-Regular.otf" media-type="font/otf" />
+  <item id="murmure-font" href="fonts/le-murmure.otf" media-type="font/otf" />
   <!--  -->
 
 
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine page-progression-direction="ltr">
-  <itemref idref="page_001"/>
-  <itemref idref="page_002"/>
-  <itemref idref="page_003"/>
-  <itemref idref="page_004"/>
+  <itemref idref="page_001" />
+  <itemref idref="page_002" />
+  <itemref idref="page_003" />
+  <itemref idref="page_004" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-004/OPS/page_001.xhtml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-004/OPS/page_001.xhtml
@@ -1,8 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
 <title>Page Progression 004</title>
-<meta name="viewport" content="width=900, height=600"/>
-<link rel="stylesheet" href="fixed.css"/>
+<meta name="viewport" content="width=900, height=600" />
+<link rel="stylesheet" href="fixed.css" />
 </head>
 <body id="p1" dir="rtl">
 

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-004/OPS/page_002.xhtml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-004/OPS/page_002.xhtml
@@ -1,8 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
 <title>Page Progression 004</title>
-<meta name="viewport" content="width=900, height=600"/>
-<link rel="stylesheet" href="fixed.css"/>
+<meta name="viewport" content="width=900, height=600" />
+<link rel="stylesheet" href="fixed.css" />
 </head>
 <body id="p2" dir="rtl">
 

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-004/OPS/page_003.xhtml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-004/OPS/page_003.xhtml
@@ -1,8 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
 <title>Page Progression 004</title>
-<meta name="viewport" content="width=900, height=600"/>
-<link rel="stylesheet" href="fixed.css"/>
+<meta name="viewport" content="width=900, height=600" />
+<link rel="stylesheet" href="fixed.css" />
 </head>
 <body id="p3" dir="rtl">
 

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-004/OPS/page_004.xhtml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/page-progression-004/OPS/page_004.xhtml
@@ -1,8 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
 <title>Page Progression 004</title>
-<meta name="viewport" content="width=900, height=600"/>
-<link rel="stylesheet" href="fixed.css"/>
+<meta name="viewport" content="width=900, height=600" />
+<link rel="stylesheet" href="fixed.css" />
 </head>
 <body id="p4" dir="rtl">
 

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/spine-order-001/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/spine-order-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/spine-order-001/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/spine-order-001/OPS/package.opf
@@ -9,18 +9,18 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_003" href="content_003.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_004" href="content_004.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_003" href="content_003.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_004" href="content_004.xhtml" media-type="application/xhtml+xml" />
 
 
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
-  <itemref idref="content_002"/>
-  <itemref idref="content_003"/>
-  <itemref idref="content_004"/>
+  <itemref idref="content_001" />
+  <itemref idref="content_002" />
+  <itemref idref="content_003" />
+  <itemref idref="content_004" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/unknown-collections-001/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/unknown-collections-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/unknown-collections-001/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/unknown-collections-001/OPS/package.opf
@@ -9,17 +9,17 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 
 <collection role="foo">
         <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
             <dc:title>Foo</dc:title>
         </metadata>
-        <link href="content_001.xhtml"/>
+        <link href="content_001.xhtml" />
     </collection>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/unknown-properties-002/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/unknown-properties-002/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/unknown-properties-002/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_2_Package-Document/3_3_3_Spine/unknown-properties-002/OPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001" properties="untrustworthy"/>
+  <itemref idref="content_001" properties="untrustworthy" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_3_Publication-Identifier/publication-identifier-001A/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_3_Publication-Identifier/publication-identifier-001A/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_3_Publication-Identifier/publication-identifier-001A/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_3_Publication-Identifier/publication-identifier-001A/OPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/03_Package-Document-Processing/3_3_Publication-Identifier/publication-identifier-001B/META-INF/container.xml
+++ b/tests/reading-systems/03_Package-Document-Processing/3_3_Publication-Identifier/publication-identifier-001B/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/03_Package-Document-Processing/3_3_Publication-Identifier/publication-identifier-001B/OPS/package.opf
+++ b/tests/reading-systems/03_Package-Document-Processing/3_3_Publication-Identifier/publication-identifier-001B/OPS/package.opf
@@ -9,10 +9,10 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
+  <itemref idref="content_001" />
 </spine>
 </package>

--- a/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-access-001/META-INF/container.xml
+++ b/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-access-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-access-001/OPS/package.opf
+++ b/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-access-001/OPS/package.opf
@@ -9,12 +9,12 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
-  <itemref idref="content_002"/>
+  <itemref idref="content_001" />
+  <itemref idref="content_002" />
 </spine>
 </package>

--- a/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-access-002/META-INF/container.xml
+++ b/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-access-002/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-access-002/OPS/package.opf
+++ b/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-access-002/OPS/package.opf
@@ -9,13 +9,13 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="nav"/>
-  <itemref idref="content_001"/>
-  <itemref idref="content_002"/>
+  <itemref idref="nav" />
+  <itemref idref="content_001" />
+  <itemref idref="content_002" />
 </spine>
 </package>

--- a/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-link-001/META-INF/container.xml
+++ b/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-link-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-link-001/OPS/package.opf
+++ b/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-link-001/OPS/package.opf
@@ -9,12 +9,12 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="content_001"/>
-  <itemref idref="content_002"/>
+  <itemref idref="content_001" />
+  <itemref idref="content_002" />
 </spine>
 </package>

--- a/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-link-002/META-INF/container.xml
+++ b/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-link-002/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-link-002/OPS/package.opf
+++ b/tests/reading-systems/05_Navigation-Document/5_1_Navigation-Document-Conformance/navigation-link-002/OPS/package.opf
@@ -9,13 +9,13 @@
   <dc:language>en</dc:language>
 </metadata>
 <manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="content_002" href="content_002.xhtml" media-type="application/xhtml+xml" />
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="nav"/>
-  <itemref idref="content_001"/>
-  <itemref idref="content_002"/>
+  <itemref idref="nav" />
+  <itemref idref="content_001" />
+  <itemref idref="content_002" />
 </spine>
 </package>

--- a/tests/reading-systems/06_Fixed-Layout-Documents/fixed-layout-base/META-INF/container.xml
+++ b/tests/reading-systems/06_Fixed-Layout-Documents/fixed-layout-base/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/06_Fixed-Layout-Documents/fixed-layout-base/OPS/package.opf
+++ b/tests/reading-systems/06_Fixed-Layout-Documents/fixed-layout-base/OPS/package.opf
@@ -10,22 +10,22 @@
   <meta property="rendition:layout">pre-paginated</meta>
 </metadata>
 <manifest>
-  <item id="page_001" href="page_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="page_002" href="page_002.xhtml" media-type="application/xhtml+xml"/>
-  <item id="page_003" href="page_003.xhtml" media-type="application/xhtml+xml"/>
-  <item id="page_004" href="page_004.xhtml" media-type="application/xhtml+xml"/>
-  <item id="style"    href="fixed.css" media-type="text/css"/>
-  <item id="stix-font" href="fonts/STIXTwoText-Regular.otf" media-type="font/otf"/>
-  <item id="murmure-font" href="fonts/le-murmure.otf" media-type="font/otf"/>
+  <item id="page_001" href="page_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="page_002" href="page_002.xhtml" media-type="application/xhtml+xml" />
+  <item id="page_003" href="page_003.xhtml" media-type="application/xhtml+xml" />
+  <item id="page_004" href="page_004.xhtml" media-type="application/xhtml+xml" />
+  <item id="style"    href="fixed.css" media-type="text/css" />
+  <item id="stix-font" href="fonts/STIXTwoText-Regular.otf" media-type="font/otf" />
+  <item id="murmure-font" href="fonts/le-murmure.otf" media-type="font/otf" />
   <!--  -->
 
 
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="page_001"/>
-  <itemref idref="page_002"/>
-  <itemref idref="page_003"/>
-  <itemref idref="page_004"/>
+  <itemref idref="page_001" />
+  <itemref idref="page_002" />
+  <itemref idref="page_003" />
+  <itemref idref="page_004" />
 </spine>
 </package>

--- a/tests/reading-systems/06_Fixed-Layout-Documents/fixed-layout-base/OPS/page_001.xhtml
+++ b/tests/reading-systems/06_Fixed-Layout-Documents/fixed-layout-base/OPS/page_001.xhtml
@@ -1,8 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
 <title>Fixed Layout Base</title>
-<meta name="viewport" content="width=900, height=600"/>
-<link rel="stylesheet" href="fixed.css"/>
+<meta name="viewport" content="width=900, height=600" />
+<link rel="stylesheet" href="fixed.css" />
 </head>
 <body id="p1">
 

--- a/tests/reading-systems/06_Fixed-Layout-Documents/fixed-layout-base/OPS/page_002.xhtml
+++ b/tests/reading-systems/06_Fixed-Layout-Documents/fixed-layout-base/OPS/page_002.xhtml
@@ -1,8 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
 <title>Fixed Layout Base</title>
-<meta name="viewport" content="width=900, height=600"/>
-<link rel="stylesheet" href="fixed.css"/>
+<meta name="viewport" content="width=900, height=600" />
+<link rel="stylesheet" href="fixed.css" />
 </head>
 <body id="p2">
 

--- a/tests/reading-systems/06_Fixed-Layout-Documents/fixed-layout-base/OPS/page_003.xhtml
+++ b/tests/reading-systems/06_Fixed-Layout-Documents/fixed-layout-base/OPS/page_003.xhtml
@@ -1,8 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
 <title>Fixed Layout Base</title>
-<meta name="viewport" content="width=900, height=600"/>
-<link rel="stylesheet" href="fixed.css"/>
+<meta name="viewport" content="width=900, height=600" />
+<link rel="stylesheet" href="fixed.css" />
 </head>
 <body id="p3">
 

--- a/tests/reading-systems/06_Fixed-Layout-Documents/fixed-layout-base/OPS/page_004.xhtml
+++ b/tests/reading-systems/06_Fixed-Layout-Documents/fixed-layout-base/OPS/page_004.xhtml
@@ -1,8 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
 <title>Fixed Layout Base</title>
-<meta name="viewport" content="width=900, height=600"/>
-<link rel="stylesheet" href="fixed.css"/>
+<meta name="viewport" content="width=900, height=600" />
+<link rel="stylesheet" href="fixed.css" />
 </head>
 <body id="p4">
 

--- a/tests/reading-systems/06_Fixed-Layout-Documents/fxl-viewport-crop-001/META-INF/container.xml
+++ b/tests/reading-systems/06_Fixed-Layout-Documents/fxl-viewport-crop-001/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
    <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
    </rootfiles>
 </container>

--- a/tests/reading-systems/06_Fixed-Layout-Documents/fxl-viewport-crop-001/OPS/package.opf
+++ b/tests/reading-systems/06_Fixed-Layout-Documents/fxl-viewport-crop-001/OPS/package.opf
@@ -10,21 +10,21 @@
   <meta property="rendition:layout">pre-paginated</meta>
 </metadata>
 <manifest>
-  <item id="page_001" href="page_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="page_002" href="page_002.xhtml" media-type="application/xhtml+xml"/>
-  <item id="page_003" href="page_003.xhtml" media-type="application/xhtml+xml"/>
-  <item id="page_004" href="page_004.xhtml" media-type="application/xhtml+xml"/>
-  <item id="style"    href="fixed.css" media-type="text/css"/>
-  <item id="stix-font" href="fonts/STIXTwoText-Regular.otf" media-type="font/otf"/>
+  <item id="page_001" href="page_001.xhtml" media-type="application/xhtml+xml" />
+  <item id="page_002" href="page_002.xhtml" media-type="application/xhtml+xml" />
+  <item id="page_003" href="page_003.xhtml" media-type="application/xhtml+xml" />
+  <item id="page_004" href="page_004.xhtml" media-type="application/xhtml+xml" />
+  <item id="style"    href="fixed.css" media-type="text/css" />
+  <item id="stix-font" href="fonts/STIXTwoText-Regular.otf" media-type="font/otf" />
   <!--  -->
 
 
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
 </manifest>
 <spine>
-  <itemref idref="page_001"/>
-  <itemref idref="page_002"/>
-  <itemref idref="page_003"/>
-  <itemref idref="page_004"/>
+  <itemref idref="page_001" />
+  <itemref idref="page_002" />
+  <itemref idref="page_003" />
+  <itemref idref="page_004" />
 </spine>
 </package>

--- a/tests/reading-systems/06_Fixed-Layout-Documents/fxl-viewport-crop-001/OPS/page_001.xhtml
+++ b/tests/reading-systems/06_Fixed-Layout-Documents/fxl-viewport-crop-001/OPS/page_001.xhtml
@@ -1,8 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
 <title>FXL Viewport Crop 001</title>
-<meta name="viewport" content="width=900, height=600"/>
-<link rel="stylesheet" href="fixed.css"/>
+<meta name="viewport" content="width=900, height=600" />
+<link rel="stylesheet" href="fixed.css" />
 </head>
 <body id="p1">
 

--- a/tests/reading-systems/06_Fixed-Layout-Documents/fxl-viewport-crop-001/OPS/page_002.xhtml
+++ b/tests/reading-systems/06_Fixed-Layout-Documents/fxl-viewport-crop-001/OPS/page_002.xhtml
@@ -1,8 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
 <title>FXL Viewport Crop 001</title>
-<meta name="viewport" content="width=900, height=600"/>
-<link rel="stylesheet" href="fixed.css"/>
+<meta name="viewport" content="width=900, height=600" />
+<link rel="stylesheet" href="fixed.css" />
 </head>
 <body id="p2">
 

--- a/tests/reading-systems/06_Fixed-Layout-Documents/fxl-viewport-crop-001/OPS/page_003.xhtml
+++ b/tests/reading-systems/06_Fixed-Layout-Documents/fxl-viewport-crop-001/OPS/page_003.xhtml
@@ -1,8 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
 <title>FXL Viewport Crop 001</title>
-<meta name="viewport" content="width=900, height=600"/>
-<link rel="stylesheet" href="fixed.css"/>
+<meta name="viewport" content="width=900, height=600" />
+<link rel="stylesheet" href="fixed.css" />
 </head>
 <body id="p3">
 

--- a/tests/reading-systems/06_Fixed-Layout-Documents/fxl-viewport-crop-001/OPS/page_004.xhtml
+++ b/tests/reading-systems/06_Fixed-Layout-Documents/fxl-viewport-crop-001/OPS/page_004.xhtml
@@ -1,8 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
 <head>
 <title>FXL Viewport Crop 001</title>
-<meta name="viewport" content="width=900, height=600"/>
-<link rel="stylesheet" href="fixed.css"/>
+<meta name="viewport" content="width=900, height=600" />
+<link rel="stylesheet" href="fixed.css" />
 </head>
 <body id="p4">
 

--- a/tests/reading-systems/XX-Test-Template/epub-template/META-INF/container.xml
+++ b/tests/reading-systems/XX-Test-Template/epub-template/META-INF/container.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
-   <rootfiles>
-      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
-   </rootfiles>
+  <rootfiles>
+    <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml" />
+  </rootfiles>
 </container>

--- a/tests/reading-systems/XX-Test-Template/epub-template/OPS/content_001.xhtml
+++ b/tests/reading-systems/XX-Test-Template/epub-template/OPS/content_001.xhtml
@@ -1,13 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
-<head>
-<title>Title TK</title>
-</head>
-<body>
-
-
-<p>Test passes if…</p>
-
-
-
-</body>
+  <head>
+    <title>Title</title>
+  </head>
+  <body>
+    <p>Test passes if...</p>
+  </body>
 </html>

--- a/tests/reading-systems/XX-Test-Template/epub-template/OPS/nav.xhtml
+++ b/tests/reading-systems/XX-Test-Template/epub-template/OPS/nav.xhtml
@@ -1,12 +1,12 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
-<head>
-<title>Title TK</title>
-</head>
-<body>
-<nav epub:type="toc">
-<ol>
-<li><a href="content_001.xhtml">Link to main page</a></li>
-</ol>
-</nav>
-</body>
+  <head>
+    <title>Title</title>
+  </head>
+  <body>
+    <nav epub:type="toc">
+      <ol>
+        <li><a href="content_001.xhtml">Link to main page</a></li>
+      </ol>
+    </nav>
+  </body>
 </html>

--- a/tests/reading-systems/XX-Test-Template/epub-template/OPS/package.opf
+++ b/tests/reading-systems/XX-Test-Template/epub-template/OPS/package.opf
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0" xml:lang="en" unique-identifier="pub-id">
-<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <dc:title>Title TK</dc:title>
-  <dc:date>2021-03-29</dc:date>
-  <dc:creator>Creator TK</dc:creator>
-  <dc:identifier id="pub-id">NOID</dc:identifier>
-  <meta property="dcterms:modified">2021-03-29T00:00:00Z</meta>
-  <dc:language>en</dc:language>
-</metadata>
-<manifest>
-  <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
-  <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
-</manifest>
-<spine>
-  <itemref idref="content_001"/>
-</spine>
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Title</dc:title>
+    <dc:creator>Creator</dc:creator>
+    <dc:date>2021-01-01</dc:date>
+    <dc:identifier id="pub-id">NOID</dc:identifier>
+    <dc:language>en</dc:language>
+    <meta property="dcterms:modified">2021-01-01T00:00:00Z</meta>
+  </metadata>
+  <manifest>
+    <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+    <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
+  </manifest>
+  <spine>
+    <itemref idref="content_001" />
+  </spine>
 </package>


### PR DESCRIPTION
For cleanliness, this standardizes formatting of self-closing tags in void elements, placeholder title/creator/date elements, and some indentation.