### PR TITLE
Trim/collapse whitespace in creators' names

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -182,7 +182,8 @@ async function get_test_metadata(dir_name: string): Promise<TestData[]> {
                 if (entry === undefined) {
                     return fallback;
                 } else {
-                    return typeof entry === "string" ? entry.trim().replace(/\s+/g, ' ') : entry._;
+                    const retval = typeof entry === "string" ? entry : entry._;
+                    return retval.trim().replace(/\s+/g, ' ');
                 }
             } catch {
                 return fallback;


### PR DESCRIPTION
This is necessary to avoid duplication because of https://github.com/w3c/epub-tests/blob/main/tests/confreq-rs-pkg-whitespace/OPS/package.opf#L5.