### PR TITLE
Multiple creators

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -136,6 +136,8 @@ The package document for each test must contain the following metadata, which is
 * `dc:title`: The title of the test, in sentence case. It is used in the test description and should be as concise as
   possible.
 
+* `dc:creator` (may be repeated): Creator(s) of the tests.
+
 * `dc:description`: A longer description of the test for the generated test report.
 
 * `dc:coverage`: Which section of the report the test should be listed in. The report has a separate table for each section
@@ -164,6 +166,8 @@ In this example, only the relevant metadata items are shown:
 <package xmlns="http://www.idpf.org/2007/opf" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0" xml:lang="en" unique-identifier="pub-id">
     <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
         <dc:coverage>Internationalization</dc:coverage>
+        <dc:creator>Dan Lazin</dc:creator>
+        <dc:creator>Ivan Herman</dc:creator>
         <dc:description>
             The 'dc:title' element contains text whose proper rendering requires bidi control. The element's 'dir' attribute
             is set to 'rtl'; the title should display from right to left.

--- a/docs/drafts/index.html
+++ b/docs/drafts/index.html
@@ -11,7 +11,7 @@
 				wgPublicList: "public-epub3",
 				specStatus: "base",
 				noRecTrack: true,
-				publishDate: "2021-11-11",
+				publishDate: "2021-11-18",
 				shortName: "epub-tests",
 				edDraftURI: "https://w3c.github.io/epub-tests/results/",
                 copyrightStart: "2021",

--- a/docs/drafts/results.html
+++ b/docs/drafts/results.html
@@ -11,7 +11,7 @@
 				wgPublicList: "public-epub3",
 				specStatus: "base",
 				noRecTrack: true,
-				publishDate: "2021-11-11",
+				publishDate: "2021-11-18",
 				shortName: "epub-tests-results",
 				edDraftURI: "https://w3c.github.io/epub-tests/results/",
                 copyrightStart: "2021",

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -407,8 +407,12 @@ function create_creator_list(data: ReportData): string {
     // Collect all creators into a set (i.e, to avoid duplicates)
     for (const table of data.tables) {
         for (const test of table.implementations) {
-            if (!(Constants.IGNORE_CREATOR_ID.includes(test.identifier) || Constants.IGNORE_CREATORS.includes(test.creator))) {
-                creators.add(test.creator);
+            if (!Constants.IGNORE_CREATOR_ID.includes(test.identifier)) {
+                for (const creator of test.creators) {
+                    if (!Constants.IGNORE_CREATORS.includes(creator)) {
+                        creators.add(creator)
+                    }
+                } 
             }
         }
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,7 @@
 export namespace Constants {
     /** Location for the tests themselves */
     export const TESTS_DIR: string = 'tests';
+    // export const TESTS_DIR: string = 'local_tests';
 
     /** Location for the implementation reports */
     export const TEST_RESULTS_DIR: string = 'reports';
@@ -40,7 +41,7 @@ export namespace Constants {
     export const DOC_TEST_DESCRIPTIONS: string = 'index.html';
 
     /** List of test ID-s whose creators should not be considered for display */
-    export const IGNORE_CREATOR_ID: string[] = ['package-creator-order-001', 'package-creator-dir-rtl-001', 'content_001'];
+    export const IGNORE_CREATOR_ID: string[] = ['pkg-creator-order', 'pkg-dir_creator-rtl', 'content_001'];
 
     /** List of creator names that should not be considered for display */
     export const IGNORE_CREATORS: string[] = ['Creator', '(Unknown)'];
@@ -84,7 +85,7 @@ export interface TestData {
     /**
      * Creator of the test
      */
-    creator: string;
+    creators: string[];
     /**
      * Short title of the test
      */


### PR DESCRIPTION
Modified the script to account for multiple creators in the acknowledgement section.

As an aside: I realized that we did not document the `dc:creator` metadata item in the contributors' manual :-(. So I added that.