### PR TITLE
Changing the way OPF files are found

### DIFF
--- a/docs/drafts/fragments/results.html
+++ b/docs/drafts/fragments/results.html
@@ -281,6 +281,15 @@
         <td class="pass">pass</td>
       </tr>
       <tr>
+        <td id="pkg-relative-url-results">
+          <a href="index.html#pkg-relative-url">pkg-relative-url</a>
+        </td>
+        <td class="must">true</td>
+        <td>n/a</td>
+        <td>n/a</td>
+        <td>n/a</td>
+      </tr>
+      <tr>
         <td id="pkg-spine-duplicate-item-hyperlink-results">
           <a href="index.html#pkg-spine-duplicate-item-hyperlink">pkg-spine-duplicate-item-hyperlink</a>
         </td>
@@ -1098,6 +1107,17 @@
         <td class="fail">fail</td>
         <td class="fail">fail</td>
         <td class="pass">pass</td>
+      </tr>
+      <tr>
+        <td id="pkg-relative-url-results-detailed">
+          <a href="index.html#pkg-relative-url">pkg-relative-url</a>
+        </td>
+        <td class="must">true</td>
+        <td>n/a</td>
+        <td>n/a</td>
+        <td>n/a</td>
+        <td>n/a</td>
+        <td>n/a</td>
       </tr>
       <tr>
         <td id="pkg-spine-duplicate-item-hyperlink-results-detailed">

--- a/docs/drafts/fragments/results.html
+++ b/docs/drafts/fragments/results.html
@@ -281,20 +281,16 @@
         <td class="pass">pass</td>
       </tr>
       <tr>
-<<<<<<< HEAD
-        <td id="pkg-relative-url-results">
+        <td id="pkg-relative-url-results" class="must">
           <a href="index.html#pkg-relative-url">pkg-relative-url</a>
         </td>
-        <td class="must">true</td>
+        <td>must</td>
         <td>n/a</td>
         <td>n/a</td>
         <td>n/a</td>
       </tr>
       <tr>
-        <td id="pkg-spine-duplicate-item-hyperlink-results">
-=======
         <td id="pkg-spine-duplicate-item-hyperlink-results" class="must">
->>>>>>> main
           <a href="index.html#pkg-spine-duplicate-item-hyperlink">pkg-spine-duplicate-item-hyperlink</a>
         </td>
         <td>must</td>
@@ -1113,11 +1109,10 @@
         <td class="pass">pass</td>
       </tr>
       <tr>
-<<<<<<< HEAD
-        <td id="pkg-relative-url-results-detailed">
+        <td id="pkg-relative-url-results-detailed" class="must">
           <a href="index.html#pkg-relative-url">pkg-relative-url</a>
         </td>
-        <td class="must">true</td>
+        <td>must</td>
         <td>n/a</td>
         <td>n/a</td>
         <td>n/a</td>
@@ -1125,10 +1120,7 @@
         <td>n/a</td>
       </tr>
       <tr>
-        <td id="pkg-spine-duplicate-item-hyperlink-results-detailed">
-=======
         <td id="pkg-spine-duplicate-item-hyperlink-results-detailed" class="must">
->>>>>>> main
           <a href="index.html#pkg-spine-duplicate-item-hyperlink">pkg-spine-duplicate-item-hyperlink</a>
         </td>
         <td>must</td>

--- a/docs/drafts/fragments/tests.html
+++ b/docs/drafts/fragments/tests.html
@@ -436,6 +436,21 @@
         </td>
       </tr>
       <tr>
+        <td id="pkg-relative-url">
+          <a href="https://github.com/w3c/epub-tests/tree/main/tests/pkg-relative-url">pkg-relative-url</a>
+        </td>
+        <td class="must">true</td>
+        <td>Content in relative subdirectory</td>
+        <td>The manifest refers to an XHTML file in an arbitrary subfolder that is relative to the package's own arbitrary folder. The reading system must be able to find the content.</td>
+        <td>
+          <a href="https://w3c.github.io/epub-specs/epub33/core/#confreq-root-url">(1) </a>
+          <a href="https://w3c.github.io/epub-specs/epub33/rs/#confreq-rs-pkg-manifest-url">(2) </a>
+        </td>
+        <td>
+          <a href="results.html#pkg-relative-url-results">❐</a>
+        </td>
+      </tr>
+      <tr>
         <td id="pkg-spine-duplicate-item-hyperlink">
           <a href="https://github.com/w3c/epub-tests/tree/main/tests/pkg-spine-duplicate-item-hyperlink">pkg-spine-duplicate-item-hyperlink</a>
         </td>

--- a/docs/drafts/fragments/tests.html
+++ b/docs/drafts/fragments/tests.html
@@ -436,11 +436,10 @@
         </td>
       </tr>
       <tr>
-<<<<<<< HEAD
-        <td id="pkg-relative-url">
+        <td id="pkg-relative-url" class="must">
           <a href="https://github.com/w3c/epub-tests/tree/main/tests/pkg-relative-url">pkg-relative-url</a>
         </td>
-        <td class="must">true</td>
+        <td>must</td>
         <td>Content in relative subdirectory</td>
         <td>The manifest refers to an XHTML file in an arbitrary subfolder that is relative to the package's own arbitrary folder. The reading system must be able to find the content.</td>
         <td>
@@ -452,10 +451,7 @@
         </td>
       </tr>
       <tr>
-        <td id="pkg-spine-duplicate-item-hyperlink">
-=======
         <td id="pkg-spine-duplicate-item-hyperlink" class="must">
->>>>>>> main
           <a href="https://github.com/w3c/epub-tests/tree/main/tests/pkg-spine-duplicate-item-hyperlink">pkg-spine-duplicate-item-hyperlink</a>
         </td>
         <td>must</td>

--- a/reports/xx-template.json
+++ b/reports/xx-template.json
@@ -39,6 +39,7 @@
         "pkg-manifest-url": false,
         "pkg-meta-unknown": false,
         "pkg-meta-whitespace": false,
+        "pkg-relative-url": false,
         "pkg-spine-duplicate-item-hyperlink": false,
         "pkg-spine-duplicate-item-rendering": false,
         "pkg-spine-duplicate-item-ui": false,

--- a/src/add_metadata.ts
+++ b/src/add_metadata.ts
@@ -13,7 +13,7 @@
 import * as fs_old_school from "fs";
 const fs = fs_old_school.promises;
 
-import {get_list_dir, isDirectory} from './lib/data';
+import {get_list_dir, isDirectory, get_opf_file} from './lib/data';
 import { Constants } from './lib/types';
 import { create_epub } from './lib/epub';
 
@@ -23,7 +23,8 @@ import { create_epub } from './lib/epub';
 async function main(new_metadata: string[], cut_off_pattern: string): Promise<void> {
     const dir_name: string = Constants.TESTS_DIR;
     const handle_single_test_metadata = async (file_name: string): Promise<void> => {
-        const opf_file = `${file_name}/${Constants.OPF_FILE}`;
+        const opf_file_name = await get_opf_file(file_name)
+        const opf_file = await `${file_name}/${opf_file_name}`;
         const package_xml = await fs.readFile(opf_file,'utf-8');
         const lines: string[] = package_xml.split(/\n/);
         // let us avoid doing things twice...

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -35,6 +35,49 @@ function string_comparison(a: string, b: string): number {
     else return 0;
 }
 
+
+/**
+ * Get OPF file location, following the official EPUB mechanism
+ * @param dirname 
+ * @returns fname
+ */
+export async function get_opf_file(dirname: string): Promise<string> {
+    let container_xml: string;
+    try {
+        container_xml = await fs.readFile(`${dirname}/${Constants.CONTAINER_FILE}`, 'utf-8');
+    } catch (error) {
+        console.warn(`Container.xml file could not be accessed in Directory ${dirname}`);
+        throw (`"container.xml" file could not be accessed in directory "${dirname}"`)
+    }
+    const container_js: any = await xml2js.parseStringPromise(container_xml, {
+        trim          : true,
+        normalizeTags : true,
+        explicitArray : true,
+    });
+    try {
+        return container_js.container.rootfiles[0].rootfile[0]["$"]["full-path"];
+    } catch (error) {
+        throw (`OPF file name could not be accessed in the "container.xml" file of "${dirname}"`)
+    }
+}
+
+
+/**
+ * Find and extract the OPF file, following the official EPUB mechanism
+ * 
+ * @param dirname Directory name
+ * @returns OPF content in an XML string
+ */
+async function get_opf(dirname: string): Promise<string> {
+    const fname: string = await get_opf_file(dirname);
+    try {
+        return await fs.readFile(`${dirname}/${fname}`,'utf-8');
+    } catch (error) {
+        throw (`OPF file could not be accessed in directory "${dirname}"`)
+    }
+}
+
+
 /** 
  * See if a file name path refers to a real file
  * 
@@ -237,9 +280,9 @@ async function get_test_metadata(dir_name: string): Promise<TestData[]> {
 
         let package_xml: string;
         try {
-            package_xml = await fs.readFile(`${file_name}/${Constants.OPF_FILE}`,'utf-8');
+            package_xml = await get_opf(file_name)
         } catch (error) {
-            console.warn(`Directory ${file_name} does not contain an OPF file; skipped.`);
+            console.warn(`${error}; skipped.`);
             return undefined;
         }
         const package_js: any = await xml2js.parseStringPromise(package_xml, {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,8 +20,8 @@ export namespace Constants {
     /** Base URL for the tests in the repository */
     export const TEST_URL_BASE: string = 'https://github.com/w3c/epub-tests/tree/main/tests';
 
-    /** Location of the OPF file within the test directory */
-    export const OPF_FILE: string = 'OPS/package.opf';
+    /** Location of the container file within the test directory */
+    export const CONTAINER_FILE: string = 'META-INF/container.xml';
 
     /** Location for the HTML fragment on implementation lists */
     export const IMPL_FRAGMENT: string = `${DOCS_DIR}/fragments/implementations.html`;


### PR DESCRIPTION
Instead of using a fixed name in the file, the script follows the "official" way by reading the `container.xml` file first and extract the file name from there.