### PR TITLE
Add spec reference to MOL CSS test

### DIFF
--- a/tests/mol-css/EPUB/package.opf
+++ b/tests/mol-css/EPUB/package.opf
@@ -12,8 +12,9 @@
     <link rel="dcterms:rights" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"/>
     <link rel="dcterms:rightsHolder" href="https://www.w3.org"/>
     <meta property="belongs-to-collection">should</meta>
-    <meta property="dcterms:isReferencedBy">https://www.w3.org/TR/epub-rs-33/#mol-timing-sync</meta>
     <meta property="dcterms:isReferencedBy">https://www.w3.org/TR/epub-rs-33/#mol-rendering-with-styling</meta>
+    <meta property="dcterms:isReferencedBy">https://www.w3.org/TR/epub-rs-33/#mol-timing-sync</meta>
+    <meta property="dcterms:isReferencedBy">https://www.w3.org/TR/epub-rs-33/#mol-xhtml-support</meta>
     <meta property="dcterms:modified">2022-02-10T00:00:00Z</meta>
     <meta property="media:duration" refines="#md-smil">00:02:32.732</meta>
     <meta property="media:duration">0:02:32.732</meta>


### PR DESCRIPTION
This corresponds to https://github.com/w3c/epub-specs/pull/2308.