### PR TITLE
Adding a hreflang test

### DIFF
--- a/tests/pkg-linked-records_hreflang/EPUB/content_001.xhtml
+++ b/tests/pkg-linked-records_hreflang/EPUB/content_001.xhtml
@@ -1,0 +1,15 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+  <head>
+    <title>Link to a description with hreflang</title>
+  </head>
+  <body>
+    <h1>The <code>hreflang</code> attribute must be ignored when processing the target of a <code>link</code> element</h1>
+
+    <p>This test is only relevant if the reading system supports linked resources and, in particular, the description <em>linked</em> to (rather than embedded in) the package document is shown by the user interface. If that is not the case, the relevant entry in the implementation report should be set to <code>null</code>.</p>
+
+    <p>
+      This epub's package document contains a link element to the detailed description of the test. 
+      The description itself provides the criteria for the test to pass.
+    </p>
+  </body>
+</html>

--- a/tests/pkg-linked-records_hreflang/EPUB/description.xhtml
+++ b/tests/pkg-linked-records_hreflang/EPUB/description.xhtml
@@ -1,0 +1,13 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+  <head>
+    <title>Link to a description with hreflang (description)</title>
+  </head>
+  <body>
+    <p>The test describes a situation whereby the package file includes a <code>link</code> reference to this description. The link includes a <code>hreflang</code>
+    attribute (set to 'fr', i.e., to French). This test passes if that language setting is <em>ignored</em> when rendering this description. This means that in the following quote:</p>
+
+    <blockquote><q>Le mieux est l'ennemi du bien</q></blockquote>
+
+    <p>the text must be surrounded by the usual quote characters (i.e., '"') as opposed to the '«' and '»' characters (which would be the French way).</p>
+  </body>
+</html>

--- a/tests/pkg-linked-records_hreflang/EPUB/nav.xhtml
+++ b/tests/pkg-linked-records_hreflang/EPUB/nav.xhtml
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en">
+  <head>
+    <title>Link to a description with hreflang</title>
+  </head>
+  <body>
+    <nav epub:type="toc">
+      <ol>
+        <li><a href="content_001.xhtml">Link to main page</a></li>
+      </ol>
+    </nav>
+  </body>
+</html>

--- a/tests/pkg-linked-records_hreflang/EPUB/package.opf
+++ b/tests/pkg-linked-records_hreflang/EPUB/package.opf
@@ -4,7 +4,7 @@
     <dc:coverage>Package Documents</dc:coverage>
     <dc:creator>Ivan Herman</dc:creator>
     <dc:date>2022-06-23</dc:date>
-    <dc:description>Phony.</dc:description>
+    <dc:description>Tests whether language setting in the target of a link element in the package file is affected by the hreflang attribute in the link. (It should not.) </dc:description>
     <dc:identifier id="pub-id">pkg-linked-records_hreflang</dc:identifier>
     <dc:language>en</dc:language>
     <dc:publisher>W3C</dc:publisher>

--- a/tests/pkg-linked-records_hreflang/EPUB/package.opf
+++ b/tests/pkg-linked-records_hreflang/EPUB/package.opf
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0" xml:lang="en" unique-identifier="pub-id">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:coverage>Package Documents</dc:coverage>
+    <dc:creator>Ivan Herman</dc:creator>
+    <dc:date>2022-06-23</dc:date>
+    <dc:description>Phony.</dc:description>
+    <dc:identifier id="pub-id">pkg-linked-records_hreflang</dc:identifier>
+    <dc:language>en</dc:language>
+    <dc:publisher>W3C</dc:publisher>
+    <dc:title>Link to a description with hreflang</dc:title>
+    <link rel="dcterms:description" href="description.xhtml" media-type="application/xhtml+xml" hreflang="fr"/>
+    <link rel="dcterms:rights" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"/>
+    <link rel="dcterms:rightsHolder" href="https://www.w3.org"/>
+    <meta property="dcterms:isReferencedBy">https://www.w3.org/TR/epub-rs-33/#confreq-rs-pkg-link-order</meta>
+    <meta property="dcterms:isReferencedBy">https://www.w3.org/TR/epub-33/#sec-linked-records-priority</meta>
+    <meta property="dcterms:modified">2022-06-23T00:00:00Z</meta>
+  </metadata>
+  <manifest>
+    <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml" />
+    <item id="nav" properties="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
+  </manifest>
+  <spine>
+    <itemref idref="content_001" />
+  </spine>
+</package>

--- a/tests/pkg-linked-records_hreflang/META-INF/container.xml
+++ b/tests/pkg-linked-records_hreflang/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml" />
+  </rootfiles>
+</container>

--- a/tests/pkg-linked-records_hreflang/mimetype
+++ b/tests/pkg-linked-records_hreflang/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip


### PR DESCRIPTION
The PR adds a tests to the link element in [§5.3](https://w3c.github.io/epub-specs/epub33/rs/#sec-pkg-doc-metadata) of the reading system spec, for the following statement:

> The language identified in an hreflang attribute is purely advisory. Upon fetching the resource, a reading system MUST use the language information associated with the resource to determine its language, not the metadata included in the link to the resource.

This requires careful review. I rely on the possibility of using a `<link>` to define a description:

```xml
<link rel="dcterms:description" href="description.xhtml" 
   media-type="application/xhtml+xml" hreflang="fr"/>
```

and checking whether the display of the result is done in the 'language unknown' or the French way. I hope that is correct, although two things bother me:

- (obviously) I do not know whether we have any RS that would use the linked description instead of the one given in the package file
- even if the intention is there for the RS, the package description is specified via `dc:description`, but `dc` is not allowed for the value of `rel` in the `link` element, only `dcterms:description`. Technically, these two are different.

I am all open to use a different example for `hreflang` testing, but I ran out of ideas...

(The anchors in the spec are not yet set.)
