### PR TITLE
Stylistically changed a bit the reporting files

### DIFF
--- a/docs/drafts/index.html
+++ b/docs/drafts/index.html
@@ -152,7 +152,8 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>Description of the EPUB 3.3 tests.</p>
+			<p>Description of the EPUB 3.3 tests.
+			</p>
 		</section>
 		<section id="sotd"></section>
 

--- a/docs/drafts/results.html
+++ b/docs/drafts/results.html
@@ -127,7 +127,12 @@
 	
 	<body>
 		<section id="abstract">
-			<p>Results of EPUB Testing.</p>
+			<p>This documents shows the results of EPUB 3.3 Testing.
+				It corresponds to the <a href="https://w3c.github.io/epub-specs/epub33/core/">EPUB 3.3</a> specification's 
+				exit criteria of <a href="https://w3c.github.io/epub-specs/epub33/reports/exit_criteria#exit-criteria-core-1">category 1</a>, 
+				as well as the complete <a href="https://w3c.github.io/epub-specs/epub33/reports/exit_criteria#exit-criteria-rs">exit criteria</a>
+				for the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> specification.
+			</p>
 		</section>
 		<section id="sotd"></section>
 
@@ -163,7 +168,6 @@
 				the specifications. These tests are currently <span id="test_visibility"></span> in the tables; to change their visibility, click the 
 				switch visibility button below.
 			</p>
-
 
 			<p>
 				The development of the tests is a community effort (see the <a href="./index.html#contributors">list of contributors</a>). Everyone is welcome to

--- a/docs/drafts/results.html
+++ b/docs/drafts/results.html
@@ -129,7 +129,7 @@
 		<section id="abstract">
 			<p>This documents shows the results of EPUB 3.3 Testing.
 				It corresponds to the <a href="https://w3c.github.io/epub-specs/epub33/core/">EPUB 3.3</a> specification's 
-				exit criteria of <a href="https://w3c.github.io/epub-specs/epub33/reports/exit_criteria#exit-criteria-core-1">category 1</a>, 
+				<a href="https://w3c.github.io/epub-specs/epub33/reports/exit_criteria#exit-criteria-core-1">category 1 exit criteria</a>, 
 				as well as the complete <a href="https://w3c.github.io/epub-specs/epub33/reports/exit_criteria#exit-criteria-rs">exit criteria</a>
 				for the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> specification.
 			</p>


### PR DESCRIPTION
This a counterpart of https://github.com/w3c/epub-specs/pull/2362 to add a reference back to the criteria file from the implementation report itself. 

Should be merged if https://github.com/w3c/epub-specs/pull/2362 is merged.