### PR TITLE
Fix missing comma in Kobo file

### DIFF
--- a/reports/kobo-ereader.json
+++ b/reports/kobo-ereader.json
@@ -1,7 +1,7 @@
 {
     "name": "Kobo Books",
     "ref": "https://www.kobo.com",
-    "variant": "eReader v4.33"
+    "variant": "eReader v4.33",
     "tests": {
         "cnt-css-fonts": false,
         "cnt-mathml-support": true,


### PR DESCRIPTION
Invalid JSON at the moment! No Kobo here:
https://w3c.github.io/epub-tests/results