### PR TITLE
Remove question marks from the tables

### DIFF
--- a/docs/drafts/results.html
+++ b/docs/drafts/results.html
@@ -21,8 +21,12 @@
 				background-color: hsl(355, 100%, 72%);
 			}
 
+			td.untested {
+				background-color: hsl(60, 100%, 85%);
+			}
+
 			td.na {
-				background-color: hsl(60, 100%, 79%);;
+				background-color: hsl(30, 5%, 97%);
 			}
 
 			tr.under_implemented {

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -133,7 +133,7 @@ function create_impl_reports(data: ReportData): {consolidated_results: string, c
                 for (const result of row.implementations) {
                     if (result === undefined) {
                         // This may happen if the tester has not started with a full template...
-                        const td_impl = add_child(tr, 'td', '?');
+                        const td_impl = add_child(tr, 'td', ' ');
                         td_impl.className = Constants.CLASS_UNTESTED;                        
                     } else {
                         const td_impl = add_child(tr, 'td', Score.get_td(result));

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -133,7 +133,7 @@ function create_impl_reports(data: ReportData): {consolidated_results: string, c
                 for (const result of row.implementations) {
                     if (result === undefined) {
                         // This may happen if the tester has not started with a full template...
-                        const td_impl = add_child(tr, 'td', ' ');
+                        const td_impl = add_child(tr, 'td', 'todo');
                         td_impl.className = Constants.CLASS_UNTESTED;                        
                     } else {
                         const td_impl = add_child(tr, 'td', Score.get_td(result));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -150,7 +150,7 @@ export enum Score {
     FAIL = "fail",
     PASS = "pass",
     NOT_APPLICABLE = "n/a",
-    UNTESTED = "?",
+    UNTESTED = "todo",
 }
 
 export namespace Score {


### PR DESCRIPTION
This PR proposes a tiny change in the test result tables: replace the '?' character with a simple space. The color coding of the cells, as well as the text labels ('pass', 'fail', 'n/a') does not make it necessary to use the '?' character, and an empty cell just does it. On the other hand, I found the large number of '?' characters tiring to the eye...