### PR TITLE
Adding an 'tested-by' flag to the test report.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,7 +243,7 @@ JSON file is as follows:
 
 * `ref` (optional): A URL that creates a link on the name of the reading system in the implementation report.
 
-* `official` (optional): If set to `true`, the tests have been performed by a persons that officially represent the implementers of the reading system for the purpose of testing.
+* `tested-by` (optional): If set to `implementer` the tests have been performed by the implementers of the reading system, otherwise it should be set to `third-party`.
 
 * `tests`: An object with the list of the implementation results. Each key is a test's unique identifier (its `dc:identifier`) with a
   value of `true`, `false`, `"n/a"`, or `null` for a test that passes, fails, is not applicable (i.e., is not implemented for some reasons), or is not yet tested, respectively. If a test is not listed, its value is considered to be `null`. The implementation report will show "?" for `null`, indicating that the implementation has not run the test.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,7 +255,7 @@ Here is an example of a small test report:
     "name"     : "ACME Books",
     "ref"      : "https://www.example.org/acme",
     "variant"  : "iOS, v1.0",
-    "official" : true,
+    "tested-by" : "implementer",
     "tests" : {
         "pub-cmt-gif": true,
         "pub-cmt-jpeg": true,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,16 +243,19 @@ JSON file is as follows:
 
 * `ref` (optional): A URL that creates a link on the name of the reading system in the implementation report.
 
+* `official` (optional): If set to `true`, the tests have been performed by a persons that officially represent the implementers of the reading system for the purpose of testing.
+
 * `tests`: An object with the list of the implementation results. Each key is a test's unique identifier (its `dc:identifier`) with a
-  value of `true`, `false`, `"n/a"`, or `null` for a test that passes, fails, is not applicable (i.e., is not implemented for some reasons), or is not yet tested, respectively. If a test is not listed, or its value is considered to be `null`. The implementation report will show a value of "?" for `null`, indicating that the implementation has not run the test.
+  value of `true`, `false`, `"n/a"`, or `null` for a test that passes, fails, is not applicable (i.e., is not implemented for some reasons), or is not yet tested, respectively. If a test is not listed, its value is considered to be `null`. The implementation report will show "?" for `null`, indicating that the implementation has not run the test.
 
 Here is an example of a small test report:
 
 ```json
 {
-    "name"  : "ACME Books",
-    "ref"   : "https://www.example.org/acme",
-    "variant" : "iOS, v1.0",
+    "name"     : "ACME Books",
+    "ref"      : "https://www.example.org/acme",
+    "variant"  : "iOS, v1.0",
+    "official" : true,
     "tests" : {
         "pub-cmt-gif": true,
         "pub-cmt-jpeg": true,

--- a/generate/src/deno.jsonc
+++ b/generate/src/deno.jsonc
@@ -1,7 +1,7 @@
 {
     "description": "Generation of index and resolutions' files for EPUB tests and test results.",
-    // Version 1.1.0 adds the concept and management of deprecated tests
-    "version": "1.1.1.",
+    // Version 1.2.0 adds the extra "official" flag to the test results
+    "version": "1.2.0.",
     "compilerOptions": {
         "lib": ["dom", "dom.iterable", "dom.asynciterable", "esnext", "deno.ns"]
     },

--- a/generate/src/deno.jsonc
+++ b/generate/src/deno.jsonc
@@ -1,6 +1,6 @@
 {
     "description": "Generation of index and resolutions' files for EPUB tests and test results.",
-    // Version 1.2.0 adds the extra "official" flag to the test results
+    // Version 1.2.0 adds the extra "tested-by" field to the test results
     "version": "1.2.0.",
     "compilerOptions": {
         "lib": ["dom", "dom.iterable", "dom.asynciterable", "esnext", "deno.ns"]

--- a/generate/src/lib/data.ts
+++ b/generate/src/lib/data.ts
@@ -174,10 +174,11 @@ async function getAnImplementationReport(fname: string): Promise<ImplementationR
     const raw_data = await Deno.readTextFile(fname);
     const raw_report: Raw_ImplementationReport = JSON.parse(raw_data) as Raw_ImplementationReport;
     return {
-        name    : raw_report.name,
-        ref     : raw_report.ref,
-        variant : raw_report.variant,
-        tests   : transform_tests(raw_report.tests),
+        name     : raw_report.name,
+        ref      : raw_report.ref,
+        variant  : raw_report.variant,
+        official : raw_report.official,
+        tests    : transform_tests(raw_report.tests),
     }
 }
 
@@ -543,8 +544,9 @@ export function getTemplate(report: ReportData): Raw_ImplementationReport {
     }
 
     return {
-        "name"  : "(Implementation's name)",
-        "ref"   : "https://www.example.com",
-        "tests" : test_list,
+        "name"     : "(Implementation's name)",
+        "ref"      : "https://www.example.com",
+        "official" : false,
+        "tests"    : test_list,
     }
 }

--- a/generate/src/lib/data.ts
+++ b/generate/src/lib/data.ts
@@ -20,6 +20,7 @@ import {
     Implementer, ReportData,
     ReqType,
     Constants,
+    TESTED_BY,
 } from './types.ts';
 
 
@@ -174,11 +175,11 @@ async function getAnImplementationReport(fname: string): Promise<ImplementationR
     const raw_data = await Deno.readTextFile(fname);
     const raw_report: Raw_ImplementationReport = JSON.parse(raw_data) as Raw_ImplementationReport;
     return {
-        name     : raw_report.name,
-        ref      : raw_report.ref,
-        variant  : raw_report.variant,
-        official : raw_report.official,
-        tests    : transform_tests(raw_report.tests),
+        name        : raw_report.name,
+        ref         : raw_report.ref,
+        variant     : raw_report.variant,
+        "tested-by" : raw_report["tested-by"] || TESTED_BY.IMPLEMENTER,
+        tests       : transform_tests(raw_report.tests),
     }
 }
 
@@ -544,9 +545,9 @@ export function getTemplate(report: ReportData): Raw_ImplementationReport {
     }
 
     return {
-        "name"     : "(Implementation's name)",
-        "ref"      : "https://www.example.com",
-        "official" : false,
-        "tests"    : test_list,
+        "name"      : "(Implementation's name)",
+        "ref"       : "https://www.example.com",
+        "tested-by" : TESTED_BY.IMPLEMENTER,
+        "tests"     : test_list,
     }
 }

--- a/generate/src/lib/html.ts
+++ b/generate/src/lib/html.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ReportData, Implementer, HTMLFragments } from './types.ts';
-import { Constants, Score, ReqType }                   from './types.ts';
+import { Constants, Score, ReqType, TESTED_BY }        from './types.ts';
 import { JSDOM }                                       from 'jsdom';
 import { beautify } from './beautify.ts';
 
@@ -62,8 +62,8 @@ function createImplementationList(impl: Implementer[]): string {
         const li = addChild(ol, 'li');
         const name = 'ref' in implementer ? `<a href="${implementer.ref}">${implementer.name}</a>` : `${implementer.name}`;
         const fullName = "variant" in implementer ? `${name}, ${implementer.variant}` : name;
-        const official = implementer?.official === true ? " (official test results)" : "";
-        li.innerHTML = `${fullName}${official}`;
+        const tested_by = TESTED_BY.get_tester(implementer["tested-by"]);
+        li.innerHTML = `${fullName} ${tested_by}`;
     }
     // This returns, in effect, the XML serialization of the section
     return beautify(section.outerHTML);

--- a/generate/src/lib/html.ts
+++ b/generate/src/lib/html.ts
@@ -62,7 +62,7 @@ function createImplementationList(impl: Implementer[]): string {
         const li = addChild(ol, 'li');
         const name = 'ref' in implementer ? `<a href="${implementer.ref}">${implementer.name}</a>` : `${implementer.name}`;
         const fullName = "variant" in implementer ? `${name}, ${implementer.variant}` : name;
-        const official = "official" in implementer && implementer.official === true ? " (official test results)" : "";
+        const official = implementer?.official === true ? " (official test results)" : "";
         li.innerHTML = `${fullName}${official}`;
     }
     // This returns, in effect, the XML serialization of the section

--- a/generate/src/lib/html.ts
+++ b/generate/src/lib/html.ts
@@ -61,7 +61,9 @@ function createImplementationList(impl: Implementer[]): string {
     for (const implementer of impl) {
         const li = addChild(ol, 'li');
         const name = 'ref' in implementer ? `<a href="${implementer.ref}">${implementer.name}</a>` : `${implementer.name}`;
-        li.innerHTML = 'variant' in implementer ? `${name}, ${implementer.variant}` : name;
+        const fullName = "variant" in implementer ? `${name}, ${implementer.variant}` : name;
+        const official = "official" in implementer && implementer.official === true ? " (official test results)" : "";
+        li.innerHTML = `${fullName}${official}`;
     }
     // This returns, in effect, the XML serialization of the section
     return beautify(section.outerHTML);

--- a/generate/src/lib/types.ts
+++ b/generate/src/lib/types.ts
@@ -269,7 +269,14 @@ export interface Implementer {
     variant ?: string;
 
     /** If present, the name becomes a hyperlink to this URL. */
-    ref     ?: string
+    ref     ?: string;
+
+    /**
+     * If present and set to true, the tester is "official", ie,
+     * the test have been performed by someone who officially represent
+     * the implementers
+     */
+    official ?: boolean;
 }
 
 

--- a/generate/src/lib/types.ts
+++ b/generate/src/lib/types.ts
@@ -256,6 +256,22 @@ export namespace Score {
     }
 }
 
+/**
+ * Enum for the tester's status in the test results
+ */
+
+export enum TESTED_BY {
+    IMPLEMENTER = "implementer",
+    THIRD_PARTY = "third-party",
+}
+
+export namespace TESTED_BY {
+    export function get_tester(t: TESTED_BY | undefined): string {
+        // This is a bit loose; any string that is not "implementer" will lead to a third party flag.
+        // But this looseness is not really harmful for our purposes...
+        return t !== undefined && `${t}` !== "implementer" ? "(tested by a third party)" : "";
+    }
+}
 
 /**
  * Data about a single implementer: it is necessary to the final
@@ -276,7 +292,7 @@ export interface Implementer {
      * the test have been performed by someone who officially represent
      * the implementers
      */
-    official ?: boolean;
+    "tested-by" ?: TESTED_BY;
 }
 
 


### PR DESCRIPTION
As discussed on our [telco](https://w3c.github.io/pm-wg/minutes/2026-07-23.html#61ef): there is now an optional extra boolean flag in the report, called `official`. Its effect is on the [list of implementations](https://w3c.github.io/epub-tests/results#sec-implementer-list) in the report. If the flag is present, and its value is `true`, and extra remark is added. See the screenshot of my local test run:

<img width="307" height="70" alt="Screenshot 2026-07-24 at 08 54 58" src="https://github.com/user-attachments/assets/d05e37ec-1069-49ce-a4a2-e4cf64dc6596" />

